### PR TITLE
feature/info: add usage, installation, and publishing information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "spl_tool"
 version = "0.1.0"
 edition = "2021"
+authors = ["rmsyn <rmsynchls@gmail.com>"]
+repository = "https://github.com/rmsyn/jh71xx-pac"
+categories = ["embedded", "hardware-support", "no-std"]
+description = "Port of StarFive's C spl_tool with default support for VisionFive2"
+keywords = ["riscv", "visionfive2", "u-boot", "spl"]
+license = "GPL-2.0-or-later"
 
 [dependencies]
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@ Port of the C implementation of StarFive's [`spl_tool`](https://github.com/starf
 
 **WARNING** This tool is in the very earliest stages of development. It still requires a test suite, fuzzing harnesses for file formats, and real-world testing.
 
+## Usage
+
+To use the CLI applicatiom, compile with the `cli` feature:
+
+```
+$ cd spl_tool
+$ cargo run --features cli -- --file <path-to-spl-image> --create-spl-header
+# To see a full list of options
+$ cargo run --features cli -- --help
+```
+
+## Installation
+
+The CLI application requires the `cli` feature:
+
+```
+$ cd spl_tool
+$ cargo install --features cli --path .
+```
+
+## no-std compatibility
+
+The library portion of `spl_tool` is `no-std` compatible by default, and can be used in embedded/bare-metal contexts.
+
+## Alternatives
+
+- `spl_tool` (C): <https://github.com/starfive-tech/Tools/tree/master/spl_tool>
+- `vf2-header` (Rust): <https://github.com/jonirrings/vf2-header>
+
 ## License
 
 `spl_tool` Rust is licensed under the same GPLv2+ license as the original C implementation.


### PR DESCRIPTION
Adds usage and installation information to the README.

Adds publishing information for crates.io