### PR TITLE
fixup/crc32: fix CRC-32 main loop, remove header padding deserialization

### DIFF
--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -25,8 +25,8 @@ pub fn crc32(iv: u32, sv: u32, data: &[u8]) -> u32 {
 
     for &byte in data.iter() {
         let mut sum = crc32_reverse(byte as u32);
-        for _x in 0..8 {
-            sum <<= 1;
+        for x in 0..8 {
+            sum <<= (x != 0) as u32;
             crc = if ((crc ^ sum) & 0x80000000) != 0 {
                 (crc << 1) ^ sv
             } else {

--- a/src/spl_header.rs
+++ b/src/spl_header.rs
@@ -218,11 +218,9 @@ impl TryFrom<&[u8]> for UbootSplHeader {
             let bofs = u32::from_le_bytes(val[idx..idx.saturating_add(WORD_LEN)].try_into()?);
             idx = idx.saturating_add(WORD_LEN);
 
-            // deserialize `zro2` reserved padding
-            // TODO: should we reject non-zero padding here?
-            // If CRC32 validates, the header should be valid.
-            // Maybe too early to reject here.
-            let zro2: [u8; RES_PAD2_LEN] = val[idx..idx.saturating_add(RES_PAD2_LEN)].try_into()?;
+            // skip deserializing `zro2` reserved padding
+            // It doesn't matter what is in this field, so ignore it.
+            let zro2 = [0u8; RES_PAD2_LEN];
             idx = idx.saturating_add(RES_PAD2_LEN);
 
             // deserialize VERS field from buffer
@@ -239,13 +237,10 @@ impl TryFrom<&[u8]> for UbootSplHeader {
 
             // deserialize CRCS field from buffer
             let crcs = u32::from_le_bytes(val[idx..idx.saturating_add(WORD_LEN)].try_into()?);
-            idx = idx.saturating_add(WORD_LEN);
 
-            // deserialize `zro3` reserved padding
-            // TODO: should we reject non-zero padding here?
-            // If CRC32 validates, the header should be valid.
-            // Maybe too early to reject here.
-            let zro3: [u8; RES_PAD3_LEN] = val[idx..idx.saturating_add(RES_PAD2_LEN)].try_into()?;
+            // skip deserializing `zro3` reserved padding
+            // It doesn't matter what is in this field, so ignore it.
+            let zro3 = [0u8; RES_PAD3_LEN];
 
             Ok(Self {
                 sofs,


### PR DESCRIPTION
Fixes the main CRC-32 calculation loop. The `sum` value should not be shifted on the first round.

Ignores deserializing reserved padding header fields. The contents of the fields can be anything, so save resources by ignoring the fields during deserialization.